### PR TITLE
Bump versions, and depend on Class::Method::Modifiers 2.15

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for MIME-Signature
 
+0.23    2023-03-02
+        Update to depend on Class::Method::Modifiers 2.16
+        Update versions of MIME::Disclaimer and MIME::Signature to 0.23
+
 0.2	2019-10-05 17:22
 	Added MIME::Disclaimer and bin/add-disclaimer
 	as contribution from Chris Scheller.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,7 +28,7 @@ WriteMakefile(
         'HTML::Parser'             => 0,
         'MIME::Parser'             => 0,
         'Path::Tiny'               => 0,
-        'Class::Method::Modifiers' => 0,
+        'Class::Method::Modifiers' => 2.16,
     },
     TEST_REQUIRES => {
         'Test::More' => 0,

--- a/lib/MIME/Disclaimer.pm
+++ b/lib/MIME/Disclaimer.pm
@@ -8,7 +8,7 @@ use parent -norequire, 'MIME::Signature';
 use MIME::Signature qw(_decoded_body _replace_body);
 use Class::Method::Modifiers;
 
-our $VERSION = '0.17';
+our $VERSION = '0.23'; # keep in sync with MIME::Signature
 
 use constant EMPTY           => '';
 use constant NEWLINE         => "\n";

--- a/lib/MIME/Signature.pm
+++ b/lib/MIME/Signature.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base 'Exporter';
 
-our $VERSION = '0.22';
+our $VERSION = '0.23'; # Keep in sync with MIME::Disclaimer
 
 use Carp qw(croak);
 use Encode qw(decode encode encode_utf8);


### PR DESCRIPTION
Class::Method::Modifiers version < 2.15 are subtly broken in Perl 5.37.9, this in turn breaks MIME::Signature/MIME::Disclaimer.

I have created https://github.com/moose/Class-Method-Modifiers/pull/9 which should fix Class::Method::Modifiers. This patch should be applied once that (or an equivalent fix) is merged and a new version is released.

I have asked the owner of that repo to coordinate with this PR.

See:
https://github.com/Perl/perl5/pull/20357
https://rt.cpan.org/Ticket/Display.html?id=146848
https://github.com/Perl/perl5/issues/20885
https://github.com/fany/MIME-Signature/issues/3